### PR TITLE
Add configurable inline code color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ can see now.
 - [Configuration via config file](https://github.com/sysid/inka2/wiki/Config)
 - [Images support](https://github.com/sysid/inka2/wiki/Creating-cards#images)
 - [MathJax support](https://github.com/sysid/inka2/wiki/Mathjax)
-- [Code highlight](https://github.com/sysid/inka2/wiki/Code-highlight)
+- [Code highlight](https://github.com/sysid/inka2/wiki/Code-highlight) with customizable inline code styling
 - [Hashing (for better performance)](https://github.com/sysid/inka2/wiki/Hashing)
 
 ### nvim Integration
@@ -124,3 +124,19 @@ inka2 collect path/to/cards.md path/to/folder
 ```
 
 You can find more information on the [documentation page](https://github.com/sysid/inka2/wiki/Adding-cards-to-Anki).
+
+### Configuration
+
+**inka2** can be customized via a `config.ini` file. Key configuration options include:
+
+#### Styling Options
+
+```ini
+[highlight]
+style = monokai                    # Syntax highlighting theme
+inline_code_color = #8b5cf6        # Inline code color (default: #fa4545)
+```
+
+The `inline_code_color` option allows you to customize the color of inline code elements in your Anki cards. You can use any valid CSS color value (hex, rgb, named colors, etc.).
+
+For complete configuration options, see the [Config documentation](https://github.com/sysid/inka2/wiki/Config).

--- a/src/inka2/cli.py
+++ b/src/inka2/cli.py
@@ -240,7 +240,7 @@ def handle_note_types(anki_api: AnkiApi) -> None:
 
 code {
   background-color: #232831;
-  color: #fa4545;
+  color: """ + CONFIG.get_option_value_or_default("highlight", "inline_code_color", "#fa4545") + """;
   border: 1px solid #030a1420;
   box-shadow: 0 0.1em #00000010;
   padding: 1px 2px;

--- a/src/inka2/config.ini.original
+++ b/src/inka2/config.ini.original
@@ -15,4 +15,5 @@ cloze_field = Text
 
 [highlight]
 style = monokai
+inline_code_color = #fa4545
 

--- a/src/inka2/models/config.py
+++ b/src/inka2/models/config.py
@@ -19,6 +19,7 @@ class Config:
     _default_cloze_type = "Inka Cloze"
     _default_cloze_field = "Text"
     _default_highlight_style = "monokai"
+    _default_inline_code_color = "#fa4545"
     _default_escape_html = False
     _add_filename = False
 
@@ -56,6 +57,7 @@ class Config:
             },
             "highlight": {
                 "style": self._default_highlight_style,
+                "inline_code_color": self._default_inline_code_color,
             },
         }
 
@@ -75,9 +77,16 @@ class Config:
         """Get value of the config option"""
         return self._config[section][key]
 
+    def get_option_value_or_default(self, section: str, key: str, default: str) -> str:
+        """Get value of the config option, or return default if not found"""
+        try:
+            return self._config[section][key]
+        except KeyError:
+            return default
+
     def update_option_value(self, section: str, key: str, new_value: str):
         """Update value of the config option"""
-        if key not in self._config[section]:
+        if section not in self._config or key not in self._config[section]:
             raise KeyError
 
         self._config[section][key] = new_value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ def default_config_string():
         "\n"
         "[highlight]\n"
         "style = monokai\n"
+        "inline_code_color = #fa4545\n"
         "\n"
     )
 


### PR DESCRIPTION
## Summary

Adds a new configuration option `inline_code_color` to customize the color of inline code elements in Anki cards while maintaining backward compatibility.

## Changes

- Added `inline_code_color` configuration option to `[highlight]` section with red (#fa4545) as default
- Implemented `get_option_value_or_default()` method in Config class for safe config retrieval

## Backward Compatibility

This is a non-breaking change:
- Existing configurations without this option will continue using the current red color (#fa4545)
